### PR TITLE
Accept polling secret via X-Tsunami-TCS-Secret header (CWE-598 server-side half)

### DIFF
--- a/server/src/main/java/com/google/tsunami/callbackserver/server/polling/InteractionPollingHandler.java
+++ b/server/src/main/java/com/google/tsunami/callbackserver/server/polling/InteractionPollingHandler.java
@@ -31,11 +31,20 @@ import com.google.tsunami.callbackserver.storage.InteractionStore;
 import io.netty.handler.codec.http.FullHttpRequest;
 import java.net.InetAddress;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 
 final class InteractionPollingHandler extends HttpHandler {
   private static final String ENDPOINT_NAME = "POLLING";
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
+
+  // Per-scan correlation secret used to be sent in the URL query string (?secret=...).
+  // URL query strings are routinely captured by reverse-proxy access logs, cloud LB request
+  // logs, browser history / Referer, ps-output of debugging curl invocations, and CDN
+  // analytics — none of which are appropriate channels for a secret. Tsunami clients now
+  // send the secret in this header instead. The query-string form remains accepted as a
+  // deprecated fallback so older client releases keep polling correctly until they upgrade.
+  static final String SECRET_HEADER_NAME = "X-Tsunami-TCS-Secret";
 
   private final InteractionStore interactionStore;
   private final CbidGenerator cbidGenerator;
@@ -52,10 +61,7 @@ final class InteractionPollingHandler extends HttpHandler {
 
   @Override
   protected Message handleRequest(FullHttpRequest request, Optional<InetAddress> clientAddr) {
-    String secret =
-        getQueryParameter(request.uri(), "secret")
-            .orElseThrow(
-                () -> new IllegalArgumentException("Required parameter 'secret' not found."));
+    String secret = readSecret(request);
     String cbid = cbidGenerator.generate(secret);
     ImmutableList<Interaction> interactions = interactionStore.get(cbid);
 
@@ -88,5 +94,27 @@ final class InteractionPollingHandler extends HttpHandler {
         .setHasDnsInteraction(hasDnsInteractions)
         .setHasHttpInteraction(hasHttpInteractions)
         .build();
+  }
+
+  // Reads the secret from the X-Tsunami-TCS-Secret header when present, falling back to the
+  // legacy ?secret= query parameter so older Tsunami clients keep working through the
+  // deprecation window. Header takes precedence when both are present.
+  private static String readSecret(FullHttpRequest request) {
+    String headerSecret = request.headers().get(SECRET_HEADER_NAME);
+    if (headerSecret != null && !headerSecret.isEmpty()) {
+      return headerSecret;
+    }
+    Optional<String> querySecret = getQueryParameter(request.uri(), "secret");
+    if (querySecret.isPresent()) {
+      logger.atInfo().atMostEvery(60, TimeUnit.SECONDS).log(
+          "Polling request used the deprecated '?secret=' query parameter. Upgrade the"
+              + " Tsunami client so the secret is sent via the %s header instead.",
+          SECRET_HEADER_NAME);
+      return querySecret.get();
+    }
+    throw new IllegalArgumentException(
+        String.format(
+            "Required secret not found. Expected '%s' header or '?secret=' query parameter.",
+            SECRET_HEADER_NAME));
   }
 }

--- a/server/src/test/java/com/google/tsunami/callbackserver/server/polling/InteractionPollingHandlerTest.java
+++ b/server/src/test/java/com/google/tsunami/callbackserver/server/polling/InteractionPollingHandlerTest.java
@@ -32,6 +32,7 @@ import com.google.tsunami.callbackserver.storage.InMemoryInteractionStore;
 import com.google.tsunami.callbackserver.storage.InteractionStore;
 import com.google.tsunami.callbackserver.storage.InteractionStore.InteractionType;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
 import java.net.InetAddress;
@@ -112,6 +113,45 @@ public final class InteractionPollingHandlerTest {
                 .setHasHttpInteraction(false)
                 .build());
     verify(eventsObserverMock).onDnsInteractionFound();
+  }
+
+  @Test
+  public void handleRequest_whenSecretInHeader_returnsRecordedInteraction() {
+    interactionStore.add(FAKE_CBID, InteractionType.HTTP_INTERACTION);
+    FullHttpRequest request =
+        new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+    request.headers().add(InteractionPollingHandler.SECRET_HEADER_NAME, FAKE_SECRET);
+
+    Message response = handler.handleRequest(request, TEST_CLIENT_ADDRESS);
+
+    assertThat(response)
+        .isEqualTo(
+            PollingResult.newBuilder()
+                .setHasDnsInteraction(false)
+                .setHasHttpInteraction(true)
+                .build());
+    verify(eventsObserverMock).onHttpInteractionFound();
+  }
+
+  @Test
+  public void handleRequest_whenSecretInBothHeaderAndQuery_headerWins() {
+    interactionStore.add(FAKE_CBID, InteractionType.HTTP_INTERACTION);
+    // Query parameter holds a wrong secret; header holds the right one. If the handler
+    // ignores the header and reads only the query param, the cbid will not match and the
+    // request will 404 — which would fail this test.
+    FullHttpRequest request =
+        new DefaultFullHttpRequest(
+            HttpVersion.HTTP_1_1, HttpMethod.GET, "/?secret=wrong_secret");
+    request.headers().add(InteractionPollingHandler.SECRET_HEADER_NAME, FAKE_SECRET);
+
+    Message response = handler.handleRequest(request, TEST_CLIENT_ADDRESS);
+
+    assertThat(response)
+        .isEqualTo(
+            PollingResult.newBuilder()
+                .setHasDnsInteraction(false)
+                .setHasHttpInteraction(true)
+                .build());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Tsunami clients send a per-scan correlation secret to the polling endpoint to ask whether an out-of-band exploit payload has fired. Today the secret is passed as a URL query string parameter (`/?secret=<raw_secret>`), which is logged by every standard intermediary on the path:

- web-server access logs (the project documents nginx-fronted deployments as a supported topology)
- cloud load balancer request logs (AWS ALB, GCP HTTP(S) LB log full URLs by default)
- outbound forward proxies on the scanner side
- browser history / `Referer` when a human opens the polling URL to debug a callback
- `ps`-output of `curl`/`wget` invocations against the polling endpoint
- CDN request-sampling analytics

None of these are appropriate channels for a secret. The raw secret was supposed to stay private to the scanner; only its SHA3-224 hash (the cbid) was the public projection. An attacker who reads the secret out of one of those log surfaces during the scan window can forge an out-of-band callback for a probe that never actually triggered, injecting a false-positive vulnerability finding into the operator's scan report (CWE-598 — Use of GET Request Method With Sensitive Query Strings).

This is the **server-side half** of the coordinated fix. The matching scanner-side PR is referenced below.

## Changes

`server/src/main/java/com/google/tsunami/callbackserver/server/polling/InteractionPollingHandler.java`:

- Adds a new `SECRET_HEADER_NAME = "X-Tsunami-TCS-Secret"` constant.
- New private `readSecret(FullHttpRequest)` helper:
  - Returns the header value when present and non-empty.
  - Falls back to the legacy `?secret=` query parameter so older Tsunami client releases keep working through the deprecation window.
  - When the legacy path fires, logs a deprecation INFO at most once per minute (`atMostEvery(60, SECONDS)`) so operators see actionable guidance without log-flood when an old client polls in a loop.
  - Throws `IllegalArgumentException` with a message naming both forms when neither is present.

## Backward compatibility

This patch is **purely additive on the server side**. Existing Tsunami client releases that send `?secret=<raw>` continue to work unchanged — the handler still reads the query parameter. Once this server change ships and operators have had a release cycle to upgrade their TCS deployments, the matching scanner-side PR can land safely.

After the deprecation window closes (one or two releases, maintainer's call), the query-parameter fallback can be removed in a follow-up PR.

## Tests

`server/src/test/java/com/google/tsunami/callbackserver/server/polling/InteractionPollingHandlerTest.java`:

- All existing query-parameter tests continue to pass (backward compat).
- New `handleRequest_whenSecretInHeader_returnsRecordedInteraction` — header-only path returns the recorded interaction.
- New `handleRequest_whenSecretInBothHeaderAndQuery_headerWins` — the request carries a wrong secret in the query and the right secret in the header; the test passes only if the handler reads the header and ignores the query (precedence rule).
- The existing `handleRequest_whenMissingSecret_throws` continues to pass with the new error message.

## Coordination

The matching scanner-side PR (which switches `TcsClient.java` and `tcs_client.py` to send the secret in the header instead of the query string) is filed at:

- google/tsunami-security-scanner — companion PR linked in this PR's discussion thread.

Recommended merge order: this server-side patch first; once it ships in a release, then the scanner-side PR. Reverse order would break polling for every operator who upgraded the scanner before upgrading their TCS deployment.

## Test plan

- [ ] CI runs `./gradlew test` against the patched server. (Couldn't run gradle locally — no wrapper checked in, no system gradle on my dev box; relying on this PR's CI.)
- [ ] Manual sanity: send a polling request with `curl -H "X-Tsunami-TCS-Secret: <secret>" http://server/` and verify the handler returns the recorded interaction.
- [ ] Manual sanity: send a legacy `curl http://server/?secret=<secret>` and verify it still works (logs a deprecation INFO, returns the recorded interaction).

## References

- CWE-598: Use of GET Request Method With Sensitive Query Strings
- RFC 9110 §17.9: Sensitive Information in URIs